### PR TITLE
fix: shift blue pin right on landing map

### DIFF
--- a/web/src/components/LandingMap.tsx
+++ b/web/src/components/LandingMap.tsx
@@ -28,7 +28,7 @@ function makePinIcon(color: string, active: boolean) {
 
 const PINS = [
   {
-    position: [37.7749, -122.4194] as [number, number],
+    position: [37.7749, -122.3900] as [number, number],
     color: "#60a5fa",
     user: "damian + @alexmason",
     location: "Civic Center, SF",


### PR DESCRIPTION
Moves the Civic Center pin from lng -122.4194 to -122.3900 (~170px east at zoom 13) to give it more horizontal separation.

https://claude.ai/code/session_013DCvktrqhfGt6SNUWByuR2