### PR TITLE
fix: render vignette/fade overlays inside map stacking context

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -400,13 +400,11 @@ export default function Home() {
         {/* Map as background */}
         <div className="absolute inset-0 z-0">
           <LandingMap />
+          {/* Vignette overlay — inside same stacking context so card (z-20) renders above it */}
+          <div className="absolute inset-0 z-10 vignette pointer-events-none" />
+          {/* Extra bottom fade */}
+          <div className="absolute inset-x-0 bottom-0 z-10 h-40 bg-gradient-to-t from-[#0a0a0f] to-transparent pointer-events-none" />
         </div>
-
-        {/* Vignette overlay */}
-        <div className="absolute inset-0 z-10 vignette" />
-
-        {/* Extra bottom fade */}
-        <div className="absolute inset-x-0 bottom-0 z-10 h-40 bg-gradient-to-t from-[#0a0a0f] to-transparent" />
 
         {/* Content overlay */}
         <div className="relative z-20 flex h-full flex-col justify-end pb-16 sm:pb-24">


### PR DESCRIPTION
The card (z-20) was being painted over by the vignette (z-10) because they were in different stacking contexts — the card inside the z-0 map div, the vignette in the parent section. Moving both overlays into the same z-0 div ensures z-20 > z-10 is respected and the card is no longer faded out.

https://claude.ai/code/session_013DCvktrqhfGt6SNUWByuR2