### PR TITLE
fix: add .npmrc to resolve Clerk peer deps on Vercel

### DIFF
--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
Vercel runs npm install without --legacy-peer-deps, causing a conflict between @clerk/nextjs and react@19.1.0. This flag silences the conflict.

https://claude.ai/code/session_013DCvktrqhfGt6SNUWByuR2