### PR TITLE
feat: open early access — replace waitlist with Clerk sign-in

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -381,13 +381,13 @@ export default function Home() {
                 Features
               </a>
               <a href="/request-access" className="inline-flex items-center rounded-full bg-amber-400 px-5 py-2 text-sm font-semibold text-black hover:bg-amber-300 active:scale-[.97] transition glow-amber-sm cursor-pin">
-                Get Started
+                Sign In
               </a>
             </nav>
 
             {/* Mobile CTA */}
             <a href="/request-access" className="md:hidden inline-flex items-center rounded-full bg-amber-400 px-4 py-1.5 text-sm font-semibold text-black hover:bg-amber-300 active:scale-[.97] transition cursor-pin">
-              Get Started
+              Sign In
             </a>
           </div>
         </div>
@@ -429,7 +429,7 @@ export default function Home() {
 
               <div className="mt-8 flex flex-wrap gap-4" data-animate data-delay="2">
                 <a href="/request-access" className="inline-flex items-center rounded-full bg-amber-400 px-7 py-3.5 font-semibold text-black hover:bg-amber-300 active:scale-[.97] transition glow-amber cursor-pin">
-                  Request Access
+                  Get Started — it&rsquo;s free
                 </a>
                 <a
                   href="#how-it-works"
@@ -914,22 +914,30 @@ export default function Home() {
             </div>
           </div>
 
+          {/* Early access badge */}
+          <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-amber-400/25 bg-amber-400/8 px-4 py-1.5" data-animate>
+            <span className="h-1.5 w-1.5 rounded-full bg-amber-400 pulse-soft" />
+            <span className="text-[11px] font-semibold uppercase tracking-[0.2em] text-amber-300/80">
+              Early Access
+            </span>
+          </div>
+
           <h2
             className="font-display text-4xl sm:text-6xl tracking-tight"
             data-animate
             data-delay="1"
           >
-            Be part of the map
+            You&rsquo;re in early.
             <br />
-            <em className="text-white/30 italic">from day one.</em>
+            <em className="text-white/30 italic">Drop the first pins.</em>
           </h2>
           <p
             className="mt-5 text-lg text-white/40"
             data-animate
             data-delay="2"
           >
-            RoguePoints is invite-only during beta. A small, tight community
-            building the map before everyone else.
+            The map is just getting started. Sign in and be part of it before
+            everyone else.
           </p>
 
           <div
@@ -938,23 +946,9 @@ export default function Home() {
             data-delay="3"
           >
             <a href="/request-access" className="inline-flex items-center rounded-full bg-amber-400 px-9 py-4 text-base font-semibold text-black hover:bg-amber-300 active:scale-[.97] transition glow-amber cursor-pin">
-              Request an invite
+              Sign in with Google
             </a>
           </div>
-
-          <p
-            className="mt-6 text-sm text-white/25"
-            data-animate
-            data-delay="4"
-          >
-            Already have an invite?{" "}
-            <a
-              href="#"
-              className="text-amber-400/50 underline underline-offset-2 hover:text-amber-300 transition cursor-pin"
-            >
-              Sign in &rarr;
-            </a>
-          </p>
         </div>
       </section>
 

--- a/web/src/app/request-access/page.tsx
+++ b/web/src/app/request-access/page.tsx
@@ -1,31 +1,28 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { SignIn } from "@clerk/nextjs";
 import Link from "next/link";
+import { useEffect, useState } from "react";
 
 export default function RequestAccess() {
   const [mounted, setMounted] = useState(false);
-  const [submitted, setSubmitted] = useState(false);
-
-  useEffect(() => {
-    requestAnimationFrame(() => setMounted(true));
-  }, []);
+  useEffect(() => { requestAnimationFrame(() => setMounted(true)); }, []);
 
   return (
     <div
-      className="grain relative flex h-screen w-full flex-col items-center justify-center overflow-hidden bg-[#0a0a0f]"
+      className="grain relative flex min-h-screen w-full flex-col items-center justify-center overflow-hidden bg-[#0a0a0f] py-16"
       style={{ fontFamily: "var(--font-body)" }}
     >
-      {/* ── Ambient radial glow ── */}
+      {/* Ambient glow */}
       <div
         className="pointer-events-none absolute inset-0"
         style={{
           background:
-            "radial-gradient(ellipse 55% 45% at 50% 52%, rgba(251,191,36,0.07) 0%, transparent 70%)",
+            "radial-gradient(ellipse 55% 45% at 50% 40%, rgba(251,191,36,0.07) 0%, transparent 70%)",
         }}
       />
 
-      {/* ── Faint grid ── */}
+      {/* Faint grid */}
       <div
         className="pointer-events-none absolute inset-0 opacity-[0.025]"
         style={{
@@ -35,7 +32,7 @@ export default function RequestAccess() {
         }}
       />
 
-      {/* ── Topo arcs (decorative) ── */}
+      {/* Topo arcs */}
       <svg
         className="pointer-events-none absolute inset-0 h-full w-full opacity-[0.04]"
         viewBox="0 0 800 800"
@@ -43,23 +40,14 @@ export default function RequestAccess() {
         aria-hidden="true"
       >
         {[160, 220, 290, 370, 460, 560].map((r) => (
-          <circle
-            key={r}
-            cx="400"
-            cy="430"
-            r={r}
-            fill="none"
-            stroke="#fbbf24"
-            strokeWidth="1"
-          />
+          <circle key={r} cx="400" cy="430" r={r} fill="none" stroke="#fbbf24" strokeWidth="1" />
         ))}
       </svg>
 
-      {/* ── Back link ── */}
+      {/* Back link */}
       <Link
         href="/"
         className="absolute left-6 top-6 flex items-center gap-2 text-[13px] text-white/30 transition-colors hover:text-amber-300"
-        style={{ fontFamily: "var(--font-body)" }}
       >
         <svg viewBox="0 0 16 16" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="2">
           <path d="M10 3L5 8l5 5" strokeLinecap="round" strokeLinejoin="round" />
@@ -67,9 +55,9 @@ export default function RequestAccess() {
         Back
       </Link>
 
-      {/* ── Main content ── */}
+      {/* Content */}
       <div
-        className="relative z-10 flex flex-col items-center text-center px-6"
+        className="relative z-10 flex flex-col items-center text-center px-6 w-full"
         style={{
           opacity: mounted ? 1 : 0,
           transform: mounted ? "translateY(0)" : "translateY(20px)",
@@ -77,7 +65,7 @@ export default function RequestAccess() {
         }}
       >
         {/* Pin mark */}
-        <div className="mb-8 relative">
+        <div className="mb-6 relative">
           <svg viewBox="0 0 48 64" className="h-14 w-10" aria-hidden="true">
             <defs>
               <filter id="pin-glow" x="-60%" y="-60%" width="220%" height="220%">
@@ -91,122 +79,64 @@ export default function RequestAccess() {
             />
             <circle cx="24" cy="24" r="9.5" fill="white" opacity="0.92" />
           </svg>
-          {/* Ripple */}
           <div
             className="absolute -bottom-1 left-1/2 -translate-x-1/2 h-2 w-7 rounded-full"
-            style={{
-              background: "rgba(251,191,36,0.18)",
-              animation: "pulse-soft 2.5s ease-in-out infinite",
-            }}
+            style={{ background: "rgba(251,191,36,0.18)", animation: "pulse-soft 2.5s ease-in-out infinite" }}
           />
         </div>
 
-        {/* Wordmark */}
-        <p
-          className="mb-6 text-[11px] font-medium uppercase tracking-[0.3em] text-white/25"
-          style={{ fontFamily: "var(--font-body)" }}
-        >
-          RoguePoints
-        </p>
+        {/* Early badge */}
+        <div className="mb-5 inline-flex items-center gap-2 rounded-full border border-amber-400/25 bg-amber-400/8 px-4 py-1.5">
+          <span className="h-1.5 w-1.5 rounded-full bg-amber-400 pulse-soft" />
+          <span className="text-[11px] font-semibold uppercase tracking-[0.2em] text-amber-300/80">
+            Early Access
+          </span>
+        </div>
 
         {/* Headline */}
         <h1
-          className="mb-3 text-4xl sm:text-5xl tracking-tight text-white"
-          style={{
-            fontFamily: "var(--font-display)",
-            lineHeight: 1.05,
-          }}
+          className="mb-2 text-4xl sm:text-5xl tracking-tight text-white"
+          style={{ fontFamily: "var(--font-display)", lineHeight: 1.05 }}
         >
-          Get on the map.
+          You&rsquo;re in early.
         </h1>
-
-        <p className="mb-10 max-w-xs text-[15px] leading-relaxed text-white/35">
-          Invite-only for now. Leave your email and we&rsquo;ll drop you in when a spot opens.
+        <p className="mb-8 max-w-xs text-[15px] leading-relaxed text-white/35">
+          The map is just getting started. Sign in and drop the first pins.
         </p>
 
-        {submitted ? (
-          /* ── Submitted state ── */
-          <div className="flex w-full max-w-sm flex-col items-center gap-4 text-center">
-            <div
-              className="flex h-12 w-12 items-center justify-center rounded-full"
-              style={{
-                background: "rgba(251,191,36,0.1)",
-                border: "1px solid rgba(251,191,36,0.25)",
-                boxShadow: "0 0 24px rgba(251,191,36,0.12)",
-              }}
-            >
-              <svg viewBox="0 0 20 20" className="h-5 w-5" fill="none" stroke="#fbbf24" strokeWidth="2">
-                <path d="M4 10l4.5 4.5L16 6" strokeLinecap="round" strokeLinejoin="round" />
-              </svg>
-            </div>
-            <p className="text-[15px] font-semibold text-white/80">You&rsquo;re on the list.</p>
-            <p className="text-[13px] leading-relaxed text-white/35">
-              We&rsquo;ll reach out when your spot opens up.
-            </p>
-          </div>
-        ) : (
-          <>
-            {/* Form */}
-            <form
-              onSubmit={(e) => { e.preventDefault(); setSubmitted(true); }}
-              className="flex w-full max-w-sm flex-col gap-3"
-            >
-              <div className="relative">
-                <input
-                  type="email"
-                  required
-                  placeholder="your@email.com"
-                  autoComplete="email"
-                  className="w-full rounded-2xl border bg-white/[0.03] px-5 py-4 text-[15px] text-white placeholder:text-white/20 outline-none transition-all"
-                  style={{
-                    borderColor: "rgba(255,255,255,0.08)",
-                    caretColor: "#fbbf24",
-                  }}
-                  onFocus={(e) => {
-                    e.currentTarget.style.borderColor = "rgba(251,191,36,0.35)";
-                    e.currentTarget.style.boxShadow = "0 0 0 3px rgba(251,191,36,0.08)";
-                  }}
-                  onBlur={(e) => {
-                    e.currentTarget.style.borderColor = "rgba(255,255,255,0.08)";
-                    e.currentTarget.style.boxShadow = "none";
-                  }}
-                />
-              </div>
-
-              <button
-                type="submit"
-                className="w-full rounded-2xl py-4 text-[15px] font-semibold text-black transition-all active:scale-[0.98]"
-                style={{
-                  background: "linear-gradient(135deg, #fbbf24, #f59e0b)",
-                  boxShadow: "0 4px 24px rgba(251,191,36,0.25), 0 1px 0 rgba(255,255,255,0.1) inset",
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.boxShadow = "0 6px 32px rgba(251,191,36,0.38), 0 1px 0 rgba(255,255,255,0.1) inset";
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.boxShadow = "0 4px 24px rgba(251,191,36,0.25), 0 1px 0 rgba(255,255,255,0.1) inset";
-                }}
-              >
-                Request access
-              </button>
-            </form>
-
-            {/* Sign in */}
-            <p className="mt-7 text-[13px] text-white/25">
-              Already have an invite?{" "}
-              <a href="#" className="text-white/40 underline underline-offset-2 hover:text-amber-300 transition-colors">
-                Sign in →
-              </a>
-            </p>
-          </>
-        )}
+        {/* Clerk sign-in */}
+        <SignIn
+          routing="hash"
+          appearance={{
+            variables: {
+              colorBackground: "#0d0d14",
+              colorInputBackground: "#13131e",
+              colorInputText: "#ffffff",
+              colorText: "#ffffff",
+              colorTextSecondary: "rgba(255,255,255,0.45)",
+              colorPrimary: "#fbbf24",
+              colorDanger: "#f87171",
+              borderRadius: "1rem",
+              fontFamily: "var(--font-body)",
+            },
+            elements: {
+              card: "shadow-2xl shadow-black/60 border border-white/[0.06]",
+              headerTitle: "font-display text-white",
+              headerSubtitle: "text-white/40",
+              socialButtonsBlockButton:
+                "border-white/10 bg-white/[0.04] text-white hover:bg-white/[0.08] transition-colors",
+              formFieldInput:
+                "border-white/[0.08] bg-white/[0.03] text-white focus:border-amber-400/40 focus:ring-amber-400/10",
+              footerActionLink: "text-amber-400 hover:text-amber-300",
+              dividerLine: "bg-white/[0.06]",
+              dividerText: "text-white/30",
+            },
+          }}
+        />
       </div>
 
-      {/* ── Bottom coordinates ── */}
-      <p
-        className="absolute bottom-6 left-1/2 -translate-x-1/2 text-[11px] font-mono text-white/12 tracking-widest select-none"
-        style={{ color: "rgba(255,255,255,0.1)" }}
-      >
+      {/* Coordinates */}
+      <p className="absolute bottom-6 left-1/2 -translate-x-1/2 text-[11px] font-mono tracking-widest select-none" style={{ color: "rgba(255,255,255,0.1)" }}>
         37.7749° N &nbsp;·&nbsp; 122.4194° W
       </p>
     </div>


### PR DESCRIPTION
- /request-access now shows "You're in early" + embedded Clerk sign-in
- Landing page CTAs updated: invite-only copy → early access messaging
- All sign-up fields handled by Clerk (Google OAuth pulls photo automatically)

https://claude.ai/code/session_013DCvktrqhfGt6SNUWByuR2