### PR TITLE
fix: resolve Vercel build errors for Prisma + SQLite

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint"
   },

--- a/web/prisma.config.ts
+++ b/web/prisma.config.ts
@@ -1,18 +1,9 @@
 import "dotenv/config";
 import { defineConfig } from "prisma/config";
-import { createClient } from "@libsql/client";
-import { PrismaLibSql } from "@prisma/adapter-libsql";
-
-const url = process.env["DATABASE_URL"];
-if (!url) throw new Error("DATABASE_URL is not set");
 
 export default defineConfig({
   schema: "prisma/schema.prisma",
   migrations: {
     path: "prisma/migrations",
-  },
-  datasource: {
-    url,
-    adapter: new PrismaLibSql(createClient({ url })),
   },
 });

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -4,6 +4,7 @@ generator client {
 
 datasource db {
   provider = "sqlite"
+  url      = env("DATABASE_URL")
 }
 
 // ─── Enums ────────────────────────────────────────────────────────────────────

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -1,16 +1,22 @@
 import { PrismaClient } from "@prisma/client";
-import { PrismaLibSql } from "@prisma/adapter-libsql";
-import { createClient } from "@libsql/client";
-
-const url = process.env.DATABASE_URL;
-if (!url) throw new Error("DATABASE_URL is not set");
 
 function makeClient() {
-  const adapter = new PrismaLibSql(createClient({ url: url! }));
-  return new PrismaClient({ adapter });
+  const url = process.env.DATABASE_URL;
+
+  // Turso / remote libSQL — use the driver adapter
+  if (url?.startsWith("libsql://") || url?.startsWith("wss://")) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { createClient } = require("@libsql/client");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { PrismaLibSql } = require("@prisma/adapter-libsql");
+    const adapter = new PrismaLibSql(createClient({ url }));
+    return new PrismaClient({ adapter });
+  }
+
+  // Local SQLite file — standard client
+  return new PrismaClient();
 }
 
-// In development, reuse the client across hot-reloads to avoid exhausting connections.
 declare global {
   // eslint-disable-next-line no-var
   var __prisma: ReturnType<typeof makeClient> | undefined;


### PR DESCRIPTION
- Remove invalid 'adapter' field from prisma.config.ts (CLI config doesn't support it)
- Add url = env("DATABASE_URL") to schema so prisma generate works
- db.ts: use regular PrismaClient for file: URLs, libSQL adapter only for Turso
- Add prisma generate to build script so Vercel generates the client

https://claude.ai/code/session_013DCvktrqhfGt6SNUWByuR2