### PR TITLE
fix: Prisma 7 config — url in config.ts, adapter in PrismaClient

### DIFF
--- a/web/prisma.config.ts
+++ b/web/prisma.config.ts
@@ -1,9 +1,14 @@
 import "dotenv/config";
 import { defineConfig } from "prisma/config";
 
+const url = process.env["DATABASE_URL"];
+
 export default defineConfig({
   schema: "prisma/schema.prisma",
   migrations: {
     path: "prisma/migrations",
+  },
+  datasource: {
+    url,
   },
 });

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
   provider = "sqlite"
-  url      = env("DATABASE_URL")
 }
 
 // ─── Enums ────────────────────────────────────────────────────────────────────

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -1,20 +1,13 @@
 import { PrismaClient } from "@prisma/client";
+import { PrismaLibSql } from "@prisma/adapter-libsql";
+import { createClient } from "@libsql/client";
 
 function makeClient() {
   const url = process.env.DATABASE_URL;
+  if (!url) throw new Error("DATABASE_URL is not set");
 
-  // Turso / remote libSQL — use the driver adapter
-  if (url?.startsWith("libsql://") || url?.startsWith("wss://")) {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { createClient } = require("@libsql/client");
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { PrismaLibSql } = require("@prisma/adapter-libsql");
-    const adapter = new PrismaLibSql(createClient({ url }));
-    return new PrismaClient({ adapter });
-  }
-
-  // Local SQLite file — standard client
-  return new PrismaClient();
+  const adapter = new PrismaLibSql(createClient({ url }));
+  return new PrismaClient({ adapter });
 }
 
 declare global {


### PR DESCRIPTION
Prisma 7 removed url from schema.prisma. Connection URL goes in prisma.config.ts (for migrations) and the runtime PrismaClient always uses the libSQL adapter (handles both file: and libsql:// URLs).

https://claude.ai/code/session_013DCvktrqhfGt6SNUWByuR2