### PR TITLE
feat: add admin spots system with fullscreen drill-down experience

### DIFF
--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -64,9 +64,28 @@ model Pin {
   laughCount Int @default(0)
   wowCount   Int @default(0)
 
+  // Optional link to a Spot (pin is "inside" this spot)
+  spot      Spot?    @relation(fields: [spotId], references: [id])
+  spotId    String?
+
   media     Media[]
   reactions Reaction[]
   reports   Report[]
+}
+
+// ─── Spot ──────────────────────────────────────────────────────────────────────
+// Admin-only landmark (school, park, etc.) that contains its own pins.
+
+model Spot {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+
+  name      String
+  lat       Float
+  lng       Float
+  type      String   @default("school") // "school" | future types
+
+  pins      Pin[]
 }
 
 // ─── Media ────────────────────────────────────────────────────────────────────

--- a/web/src/app/api/admin/verify/route.ts
+++ b/web/src/app/api/admin/verify/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const ADMIN_CODE = "1612";
+
+// ─── POST /api/admin/verify — check admin code ──────────────────────────────
+
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => null);
+  if (!body || body.code !== ADMIN_CODE) {
+    return NextResponse.json({ error: "Invalid code" }, { status: 403 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/web/src/app/api/spots/[id]/pins/route.ts
+++ b/web/src/app/api/spots/[id]/pins/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { requireUser } from "@/lib/auth";
+
+type Params = { params: Promise<{ id: string }> };
+
+// ─── GET /api/spots/[id]/pins — public ──────────────────────────────────────
+
+export async function GET(_req: NextRequest, { params }: Params) {
+  const { id } = await params;
+
+  const spot = await db.spot.findUnique({ where: { id } });
+  if (!spot) {
+    return NextResponse.json({ error: "Spot not found" }, { status: 404 });
+  }
+
+  const pins = await db.pin.findMany({
+    where: { spotId: id, status: "visible" },
+    select: {
+      id: true,
+      lat: true,
+      lng: true,
+      title: true,
+      body: true,
+      category: true,
+      authorId: true,
+      fireCount: true,
+      skullCount: true,
+      heartCount: true,
+      laughCount: true,
+      wowCount: true,
+      createdAt: true,
+      author: { select: { handle: true, avatarUrl: true } },
+    },
+    orderBy: { createdAt: "desc" },
+    take: 500,
+  });
+
+  return NextResponse.json(pins);
+}
+
+// ─── POST /api/spots/[id]/pins — auth required ─────────────────────────────
+
+export async function POST(req: NextRequest, { params }: Params) {
+  const user = await requireUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const spot = await db.spot.findUnique({ where: { id } });
+  if (!spot) {
+    return NextResponse.json({ error: "Spot not found" }, { status: 404 });
+  }
+
+  const body = await req.json().catch(() => null);
+  if (!body) {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { title, body: pinBody, category } = body;
+  if (
+    typeof title !== "string" ||
+    typeof pinBody !== "string" ||
+    typeof category !== "string"
+  ) {
+    return NextResponse.json(
+      { error: "title, body, category are required" },
+      { status: 400 }
+    );
+  }
+
+  const pin = await db.pin.create({
+    data: {
+      lat: spot.lat,
+      lng: spot.lng,
+      title: title.trim(),
+      body: pinBody.trim(),
+      category,
+      authorId: user.id,
+      spotId: id,
+    },
+    include: {
+      author: { select: { handle: true, avatarUrl: true } },
+    },
+  });
+
+  return NextResponse.json(pin, { status: 201 });
+}

--- a/web/src/app/api/spots/[id]/route.ts
+++ b/web/src/app/api/spots/[id]/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+
+type Params = { params: Promise<{ id: string }> };
+
+// ─── GET /api/spots/[id] — public ───────────────────────────────────────────
+
+export async function GET(_req: NextRequest, { params }: Params) {
+  const { id } = await params;
+
+  const spot = await db.spot.findUnique({
+    where: { id },
+    include: { _count: { select: { pins: true } } },
+  });
+
+  if (!spot) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(spot);
+}

--- a/web/src/app/api/spots/route.ts
+++ b/web/src/app/api/spots/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+
+const ADMIN_CODE = "1612";
+
+// ─── GET /api/spots?swLat=&swLng=&neLat=&neLng= ────────────────────────────
+// Public — returns spots inside a map bounding box.
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = req.nextUrl;
+  const swLat = parseFloat(searchParams.get("swLat") ?? "");
+  const swLng = parseFloat(searchParams.get("swLng") ?? "");
+  const neLat = parseFloat(searchParams.get("neLat") ?? "");
+  const neLng = parseFloat(searchParams.get("neLng") ?? "");
+
+  if ([swLat, swLng, neLat, neLng].some(isNaN)) {
+    return NextResponse.json(
+      { error: "swLat, swLng, neLat, neLng are required" },
+      { status: 400 }
+    );
+  }
+
+  const spots = await db.spot.findMany({
+    where: {
+      lat: { gte: swLat, lte: neLat },
+      lng: { gte: swLng, lte: neLng },
+    },
+    select: {
+      id: true,
+      name: true,
+      lat: true,
+      lng: true,
+      type: true,
+      createdAt: true,
+    },
+    orderBy: { createdAt: "desc" },
+    take: 200,
+  });
+
+  return NextResponse.json(spots);
+}
+
+// ─── POST /api/spots — admin only ───────────────────────────────────────────
+
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => null);
+  if (!body) {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (body.adminCode !== ADMIN_CODE) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { name, lat, lng, type } = body;
+  if (
+    typeof name !== "string" ||
+    typeof lat !== "number" ||
+    typeof lng !== "number"
+  ) {
+    return NextResponse.json(
+      { error: "name, lat, lng are required" },
+      { status: 400 }
+    );
+  }
+
+  const spot = await db.spot.create({
+    data: {
+      name: name.trim(),
+      lat,
+      lng,
+      type: typeof type === "string" ? type : "school",
+    },
+  });
+
+  return NextResponse.json(spot, { status: 201 });
+}

--- a/web/src/app/map/page.tsx
+++ b/web/src/app/map/page.tsx
@@ -3,8 +3,12 @@
 import dynamic from "next/dynamic";
 import { UserButton } from "@clerk/nextjs";
 import { usePinsStore, Pin } from "@/store/pins";
+import { useSpotsStore, Spot } from "@/store/spots";
 import { ComposeModal } from "@/components/ComposeModal";
 import { PinDetail } from "@/components/PinDetail";
+import { AdminLock } from "@/components/AdminLock";
+import { SpotCompose } from "@/components/SpotCompose";
+import { SpotView } from "@/components/SpotView";
 import { useCallback } from "react";
 
 const AppMap = dynamic(
@@ -14,16 +18,22 @@ const AppMap = dynamic(
 
 export default function MapPage() {
   const { dropMode, setDropMode, selectPin, composeOpen } = usePinsStore();
+  const { spotDropMode, spotComposeOpen, selectSpot } = useSpotsStore();
 
   const handlePinClick = useCallback(
     (pin: Pin) => selectPin(pin),
     [selectPin]
   );
 
+  const handleSpotClick = useCallback(
+    (spot: Spot) => selectSpot(spot),
+    [selectSpot]
+  );
+
   return (
     <div className="relative h-screen w-screen overflow-hidden bg-[#0a0a0f]">
       {/* Full-screen map */}
-      <AppMap onPinClick={handlePinClick} />
+      <AppMap onPinClick={handlePinClick} onSpotClick={handleSpotClick} />
 
       {/* ── Floating header ── */}
       <header className="pointer-events-none absolute top-0 left-0 right-0 z-20 flex items-center justify-between px-4 py-3 sm:px-6">
@@ -111,8 +121,26 @@ export default function MapPage() {
         </div>
       )}
 
+      {/* ── Spot drop mode banner ── */}
+      {spotDropMode && !spotComposeOpen && (
+        <div className="pointer-events-none absolute top-20 left-1/2 z-20 -translate-x-1/2">
+          <div className="flex items-center gap-2 rounded-full border border-purple-400/30 bg-black/70 backdrop-blur-md px-5 py-2 text-sm text-purple-300">
+            <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
+              <path d="M9.674 2.075a.75.75 0 0 1 .652 0l7.25 3.5A.75.75 0 0 1 17.5 7v.005a.75.75 0 0 1-.076.337l-.002.003-.002.004A.75.75 0 0 1 17 7.75h-.25v4.505a.75.75 0 0 1-.154.46L10.324 17.9a.75.75 0 0 1-1.148 0L2.904 12.715a.75.75 0 0 1-.154-.46V7.75H2.5a.75.75 0 0 1-.326-1.425l7.25-3.5ZM4.25 7.75v4.192l5.75 4.457 5.75-4.457V7.75H4.25Z" />
+            </svg>
+            Tap anywhere on the map to place a spot
+            <button
+              className="pointer-events-auto ml-2 text-white/40 hover:text-white transition"
+              onClick={() => useSpotsStore.getState().setSpotDropMode(false)}
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+      )}
+
       {/* ── FAB — Drop Story ── */}
-      {!composeOpen && (
+      {!composeOpen && !spotComposeOpen && (
         <button
           onClick={() => setDropMode(!dropMode)}
           className={`absolute bottom-8 right-6 z-20 flex items-center gap-2 rounded-full px-5 py-3 text-sm font-semibold shadow-xl transition-all active:scale-95 ${
@@ -133,9 +161,14 @@ export default function MapPage() {
         </button>
       )}
 
+      {/* ── Admin lock (bottom-left) ── */}
+      <AdminLock />
+
       {/* ── Overlays ── */}
       <ComposeModal />
+      <SpotCompose />
       <PinDetail />
+      <SpotView />
     </div>
   );
 }

--- a/web/src/components/AdminLock.tsx
+++ b/web/src/components/AdminLock.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState } from "react";
+import { useSpotsStore } from "@/store/spots";
+
+export function AdminLock() {
+  const { isAdmin, setAdmin, spotDropMode, setSpotDropMode } = useSpotsStore();
+  const [showDialog, setShowDialog] = useState(false);
+  const [code, setCode] = useState("");
+  const [error, setError] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError(false);
+    try {
+      const res = await fetch("/api/admin/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code }),
+      });
+      if (!res.ok) {
+        setError(true);
+        return;
+      }
+      setAdmin(true);
+      setShowDialog(false);
+      setCode("");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  // If already admin, show the "Place Spot" button
+  if (isAdmin) {
+    return (
+      <div className="absolute bottom-8 left-6 z-20 flex flex-col gap-2">
+        <button
+          onClick={() => setSpotDropMode(!spotDropMode)}
+          className={`flex items-center gap-2 rounded-full px-4 py-2.5 text-sm font-semibold shadow-xl transition-all active:scale-95 ${
+            spotDropMode
+              ? "bg-purple-400/20 border border-purple-400/50 text-purple-300"
+              : "bg-purple-500 text-white hover:bg-purple-400 shadow-purple-500/30"
+          }`}
+        >
+          <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
+            {spotDropMode ? (
+              <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
+            ) : (
+              <path d="M9.674 2.075a.75.75 0 0 1 .652 0l7.25 3.5A.75.75 0 0 1 17.5 7v.005a.75.75 0 0 1-.076.337l-.002.003-.002.004A.75.75 0 0 1 17 7.75h-.25v4.505a.75.75 0 0 1-.154.46L10.324 17.9a.75.75 0 0 1-1.148 0L2.904 12.715a.75.75 0 0 1-.154-.46V7.75H2.5a.75.75 0 0 1-.326-1.425l7.25-3.5ZM4.25 7.75v4.192l5.75 4.457 5.75-4.457V7.75H4.25Z" />
+            )}
+          </svg>
+          {spotDropMode ? "Cancel" : "Place Spot"}
+        </button>
+        <button
+          onClick={() => { setAdmin(false); setSpotDropMode(false); }}
+          className="flex items-center gap-1.5 rounded-full border border-white/10 bg-black/50 backdrop-blur-md px-3 py-1.5 text-xs text-white/40 hover:text-white/70 transition"
+        >
+          <svg viewBox="0 0 20 20" fill="currentColor" className="w-3 h-3">
+            <path fillRule="evenodd" d="M10 1a4.5 4.5 0 0 0-4.5 4.5V9H5a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-6a2 2 0 0 0-2-2h-.5V5.5A4.5 4.5 0 0 0 10 1Zm3 8V5.5a3 3 0 1 0-6 0V9h6Z" clipRule="evenodd" />
+          </svg>
+          Lock
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {/* Lock icon */}
+      <button
+        onClick={() => setShowDialog(true)}
+        className="absolute bottom-8 left-6 z-20 flex h-10 w-10 items-center justify-center rounded-full border border-white/[0.08] bg-black/50 backdrop-blur-md text-white/30 hover:text-white/60 hover:bg-black/70 transition"
+        title="Admin access"
+      >
+        <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
+          <path fillRule="evenodd" d="M10 1a4.5 4.5 0 0 0-4.5 4.5V9H5a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-6a2 2 0 0 0-2-2h-.5V5.5A4.5 4.5 0 0 0 10 1Zm3 8V5.5a3 3 0 1 0-6 0V9h6Z" clipRule="evenodd" />
+        </svg>
+      </button>
+
+      {/* Code dialog */}
+      {showDialog && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+          <div
+            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            onClick={() => { setShowDialog(false); setCode(""); setError(false); }}
+          />
+          <div className="relative w-full max-w-xs rounded-2xl border border-white/[0.08] bg-[#13131a] shadow-2xl shadow-black/60 p-6">
+            <h2 className="font-display text-lg text-white mb-1">Admin Access</h2>
+            <p className="text-xs text-white/35 mb-4">Enter the admin code to continue.</p>
+            <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+              <input
+                type="password"
+                value={code}
+                onChange={(e) => { setCode(e.target.value); setError(false); }}
+                placeholder="Code"
+                autoFocus
+                className={`w-full rounded-xl border px-4 py-2.5 text-sm text-white placeholder-white/20 outline-none bg-white/[0.04] transition ${
+                  error
+                    ? "border-red-400/50 focus:border-red-400/70 focus:ring-1 focus:ring-red-400/20"
+                    : "border-white/10 focus:border-amber-400/40 focus:ring-1 focus:ring-amber-400/20"
+                }`}
+              />
+              {error && (
+                <p className="text-xs text-red-400">Wrong code. Try again.</p>
+              )}
+              <div className="flex gap-3">
+                <button
+                  type="button"
+                  onClick={() => { setShowDialog(false); setCode(""); setError(false); }}
+                  className="flex-1 rounded-xl border border-white/10 py-2.5 text-sm text-white/50 hover:text-white hover:border-white/20 transition"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={loading || !code}
+                  className="flex-1 rounded-xl bg-amber-400 py-2.5 text-sm font-semibold text-black hover:bg-amber-300 disabled:opacity-40 disabled:cursor-not-allowed transition"
+                >
+                  {loading ? "..." : "Unlock"}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/src/components/AppMap.tsx
+++ b/web/src/components/AppMap.tsx
@@ -5,6 +5,7 @@ import { MapContainer, TileLayer, useMap, useMapEvents } from "react-leaflet";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import { usePinsStore, Pin } from "@/store/pins";
+import { useSpotsStore, Spot } from "@/store/spots";
 import { useViewportStore } from "@/store/viewport";
 
 const CATEGORY_COLORS: Record<string, string> = {
@@ -33,6 +34,29 @@ function makePinIcon(color: string): L.DivIcon {
     className: "",
     iconSize: [30, 38],
     iconAnchor: [15, 38],
+  });
+}
+
+function makeSpotIcon(): L.DivIcon {
+  const svg = `<svg viewBox="0 0 40 44" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+      <filter id="spot-shadow" x="-50%" y="-50%" width="200%" height="200%">
+        <feDropShadow dx="0" dy="2" stdDeviation="4" flood-color="#a78bfa" flood-opacity="0.7"/>
+      </filter>
+    </defs>
+    <rect x="4" y="6" width="32" height="28" rx="4" fill="#7c3aed" filter="url(#spot-shadow)"/>
+    <rect x="4" y="6" width="32" height="28" rx="4" stroke="#a78bfa" stroke-width="1.5" fill="none"/>
+    <rect x="10" y="12" width="6" height="7" rx="1" fill="white" opacity="0.85"/>
+    <rect x="24" y="12" width="6" height="7" rx="1" fill="white" opacity="0.85"/>
+    <rect x="16" y="22" width="8" height="12" rx="1" fill="#fbbf24" opacity="0.9"/>
+    <polygon points="2,10 20,0 38,10" fill="#8b5cf6"/>
+    <polygon points="2,10 20,0 38,10" stroke="#a78bfa" stroke-width="1" fill="none"/>
+  </svg>`;
+  return L.divIcon({
+    html: svg,
+    className: "",
+    iconSize: [40, 44],
+    iconAnchor: [20, 44],
   });
 }
 
@@ -74,12 +98,53 @@ function PinFetcher() {
   return null;
 }
 
+// Fetches spots from the API whenever the map viewport changes
+function SpotFetcher() {
+  const map = useMap();
+  const fetchRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => {
+    function fetchSpots() {
+      const bounds = map.getBounds();
+      const params = new URLSearchParams({
+        swLat: String(bounds.getSouth()),
+        swLng: String(bounds.getWest()),
+        neLat: String(bounds.getNorth()),
+        neLng: String(bounds.getEast()),
+      });
+      fetch(`/api/spots?${params}`)
+        .then((r) => (r.ok ? r.json() : []))
+        .then((spots) => useSpotsStore.getState().setSpots(spots))
+        .catch(() => {});
+    }
+
+    map.whenReady(fetchSpots);
+
+    function onMoveEnd() {
+      clearTimeout(fetchRef.current);
+      fetchRef.current = setTimeout(fetchSpots, 300);
+    }
+    map.on("moveend", onMoveEnd);
+    return () => {
+      map.off("moveend", onMoveEnd);
+      clearTimeout(fetchRef.current);
+    };
+  }, [map]);
+
+  return null;
+}
+
 // Handles map clicks in drop mode — reads store directly to avoid stale closures
 function MapClickHandler() {
   useMapEvents({
     click(e) {
       const { dropMode, openCompose } = usePinsStore.getState();
-      if (dropMode) openCompose({ lat: e.latlng.lat, lng: e.latlng.lng });
+      const { spotDropMode, openSpotCompose } = useSpotsStore.getState();
+      if (spotDropMode) {
+        openSpotCompose({ lat: e.latlng.lat, lng: e.latlng.lng });
+      } else if (dropMode) {
+        openCompose({ lat: e.latlng.lat, lng: e.latlng.lng });
+      }
     },
   });
   return null;
@@ -89,9 +154,10 @@ function MapClickHandler() {
 function CursorEffect() {
   const map = useMap();
   const { dropMode } = usePinsStore();
+  const { spotDropMode } = useSpotsStore();
   useEffect(() => {
-    map.getContainer().style.cursor = dropMode ? "crosshair" : "";
-  }, [map, dropMode]);
+    map.getContainer().style.cursor = dropMode || spotDropMode ? "crosshair" : "";
+  }, [map, dropMode, spotDropMode]);
   return null;
 }
 
@@ -131,11 +197,45 @@ function MarkerLayer({ onPinClick }: { onPinClick: (pin: Pin) => void }) {
   return null;
 }
 
+// Renders spot markers with a custom building SVG
+function SpotMarkerLayer({ onSpotClick }: { onSpotClick: (spot: Spot) => void }) {
+  const map = useMap();
+  const { spots } = useSpotsStore();
+  const markersRef = useRef<Map<string, L.Marker>>(new Map());
+  const onSpotClickRef = useRef(onSpotClick);
+  onSpotClickRef.current = onSpotClick;
+
+  useEffect(() => {
+    const currentIds = new Set(spots.map((s) => s.id));
+
+    for (const [id, marker] of markersRef.current) {
+      if (!currentIds.has(id)) {
+        marker.remove();
+        markersRef.current.delete(id);
+      }
+    }
+
+    for (const spot of spots) {
+      if (markersRef.current.has(spot.id)) continue;
+      const marker = L.marker([spot.lat, spot.lng], { icon: makeSpotIcon() })
+        .addTo(map)
+        .on("click", (e) => {
+          L.DomEvent.stopPropagation(e);
+          onSpotClickRef.current(spot);
+        });
+      markersRef.current.set(spot.id, marker);
+    }
+  }, [spots, map]);
+
+  return null;
+}
+
 type Props = {
   onPinClick: (pin: Pin) => void;
+  onSpotClick: (spot: Spot) => void;
 };
 
-export function AppMap({ onPinClick }: Props) {
+export function AppMap({ onPinClick, onSpotClick }: Props) {
   const { latitude, longitude, zoom } = useViewportStore();
 
   return (
@@ -153,9 +253,11 @@ export function AppMap({ onPinClick }: Props) {
         maxZoom={20}
       />
       <PinFetcher />
+      <SpotFetcher />
       <MapClickHandler />
       <CursorEffect />
       <MarkerLayer onPinClick={onPinClick} />
+      <SpotMarkerLayer onSpotClick={onSpotClick} />
     </MapContainer>
   );
 }

--- a/web/src/components/SpotCompose.tsx
+++ b/web/src/components/SpotCompose.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState } from "react";
+import { useSpotsStore } from "@/store/spots";
+
+export function SpotCompose() {
+  const { spotComposeOpen, pendingSpotCoords, closeSpotCompose, addSpot } =
+    useSpotsStore();
+  const [name, setName] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!spotComposeOpen || !pendingSpotCoords) return null;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name.trim() || !pendingSpotCoords) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/spots", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          lat: pendingSpotCoords.lat,
+          lng: pendingSpotCoords.lng,
+          type: "school",
+          adminCode: "1612",
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error ?? "Failed to create spot");
+      }
+      const spot = await res.json();
+      addSpot(spot);
+      setName("");
+      closeSpotCompose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={closeSpotCompose}
+      />
+      <div className="relative w-full max-w-lg rounded-2xl border border-white/[0.08] bg-[#13131a] shadow-2xl shadow-black/60 p-6">
+        <div className="flex items-center justify-between mb-5">
+          <div>
+            <h2 className="font-display text-xl text-white">Place a Spot</h2>
+            <p className="text-xs text-white/35 mt-0.5 font-mono">
+              {pendingSpotCoords.lat.toFixed(5)}, {pendingSpotCoords.lng.toFixed(5)}
+            </p>
+          </div>
+          <button
+            onClick={closeSpotCompose}
+            className="flex h-8 w-8 items-center justify-center rounded-full bg-white/5 text-white/40 hover:text-white hover:bg-white/10 transition"
+          >
+            <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
+              <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
+            </svg>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div>
+            <label className="text-[11px] uppercase tracking-widest text-white/35 mb-2 block">
+              Name <span className="text-white/20 normal-case tracking-normal">(e.g. Glens Falls High School)</span>
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value.slice(0, 80))}
+              placeholder="Enter spot name..."
+              maxLength={80}
+              required
+              autoFocus
+              className="w-full rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2.5 text-sm text-white placeholder-white/20 outline-none focus:border-purple-400/40 focus:ring-1 focus:ring-purple-400/20 transition"
+            />
+            <div className="text-right text-[10px] text-white/20 mt-1">{name.length}/80</div>
+          </div>
+
+          {error && (
+            <p className="text-sm text-red-400 bg-red-400/10 rounded-lg px-3 py-2">{error}</p>
+          )}
+
+          <div className="flex gap-3 pt-1">
+            <button
+              type="button"
+              onClick={closeSpotCompose}
+              className="flex-1 rounded-xl border border-white/10 py-2.5 text-sm text-white/50 hover:text-white hover:border-white/20 transition"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={loading || !name.trim()}
+              className="flex-1 rounded-xl bg-purple-500 py-2.5 text-sm font-semibold text-white hover:bg-purple-400 disabled:opacity-40 disabled:cursor-not-allowed transition"
+            >
+              {loading ? "Placing..." : "Place Spot"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/SpotView.tsx
+++ b/web/src/components/SpotView.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSpotsStore } from "@/store/spots";
+import type { Pin } from "@/store/pins";
+
+const CATEGORIES = [
+  { id: "funny", label: "Funny", color: "border-amber-400/50 text-amber-300 bg-amber-400/10" },
+  { id: "mystery", label: "Mystery", color: "border-purple-400/50 text-purple-300 bg-purple-400/10" },
+  { id: "danger", label: "Danger", color: "border-red-400/50 text-red-300 bg-red-400/10" },
+  { id: "legend", label: "Legend", color: "border-blue-400/50 text-blue-300 bg-blue-400/10" },
+  { id: "wholesome", label: "Wholesome", color: "border-emerald-400/50 text-emerald-300 bg-emerald-400/10" },
+  { id: "other", label: "Other", color: "border-white/20 text-white/50 bg-white/5" },
+] as const;
+
+const CATEGORY_BADGE: Record<string, string> = {
+  funny: "border-amber-400/40 text-amber-300 bg-amber-400/10",
+  mystery: "border-purple-400/40 text-purple-300 bg-purple-400/10",
+  danger: "border-red-400/40 text-red-300 bg-red-400/10",
+  legend: "border-blue-400/40 text-blue-300 bg-blue-400/10",
+  wholesome: "border-emerald-400/40 text-emerald-300 bg-emerald-400/10",
+  other: "border-white/20 text-white/40 bg-white/5",
+};
+
+function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function PinCard({ pin }: { pin: Pin }) {
+  const badge = CATEGORY_BADGE[pin.category] ?? CATEGORY_BADGE.other;
+  return (
+    <div className="rounded-xl border border-white/[0.06] bg-white/[0.03] p-4 hover:bg-white/[0.05] transition">
+      <div className="flex items-center gap-2 mb-2">
+        <span className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] ${badge}`}>
+          {pin.category}
+        </span>
+        <span className="text-[10px] text-white/25">{timeAgo(pin.createdAt)}</span>
+      </div>
+      <h4 className="text-sm font-semibold text-white mb-1">{pin.title}</h4>
+      <p className="text-sm text-white/50 italic font-display leading-relaxed">
+        &ldquo;{pin.body}&rdquo;
+      </p>
+      <div className="flex items-center gap-2 mt-3">
+        {pin.author?.avatarUrl ? (
+          <img
+            src={pin.author.avatarUrl}
+            alt={pin.author.handle}
+            className="h-5 w-5 rounded-full object-cover ring-1 ring-white/10"
+          />
+        ) : (
+          <div className="h-5 w-5 rounded-full bg-amber-400/20 flex items-center justify-center text-amber-300 text-[9px] font-bold">
+            {pin.author?.handle?.[0]?.toUpperCase() ?? "?"}
+          </div>
+        )}
+        <span className="text-xs text-white/40">@{pin.author?.handle ?? "unknown"}</span>
+      </div>
+    </div>
+  );
+}
+
+export function SpotView() {
+  const { selectedSpot, spotPins, selectSpot, setSpotPins, addSpotPin } =
+    useSpotsStore();
+
+  const [loading, setLoading] = useState(false);
+  const [composeOpen, setComposeOpen] = useState(false);
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [category, setCategory] = useState("funny");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fetch pins when a spot is selected
+  useEffect(() => {
+    if (!selectedSpot) return;
+    setLoading(true);
+    fetch(`/api/spots/${selectedSpot.id}/pins`)
+      .then((r) => (r.ok ? r.json() : []))
+      .then((pins) => setSpotPins(pins))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [selectedSpot, setSpotPins]);
+
+  if (!selectedSpot) return null;
+
+  async function handleSubmitPin(e: React.FormEvent) {
+    e.preventDefault();
+    if (!title.trim() || !body.trim() || !selectedSpot) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/spots/${selectedSpot.id}/pins`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: title.trim(),
+          body: body.trim(),
+          category,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error ?? "Failed to add story");
+      }
+      const pin = await res.json();
+      addSpotPin(pin);
+      setTitle("");
+      setBody("");
+      setCategory("funny");
+      setComposeOpen(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col bg-[#0a0a0f]">
+      {/* Header */}
+      <header className="flex items-center justify-between border-b border-white/[0.06] px-5 py-4 sm:px-8">
+        <div className="flex items-center gap-3">
+          {/* Spot icon */}
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-purple-500/20 border border-purple-400/30">
+            <svg viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5 text-purple-400">
+              <path d="M9.674 2.075a.75.75 0 0 1 .652 0l7.25 3.5A.75.75 0 0 1 17.5 7v.005a.75.75 0 0 1-.076.337l-.002.003-.002.004A.75.75 0 0 1 17 7.75h-.25v4.505a.75.75 0 0 1-.154.46L10.324 17.9a.75.75 0 0 1-1.148 0L2.904 12.715a.75.75 0 0 1-.154-.46V7.75H2.5a.75.75 0 0 1-.326-1.425l7.25-3.5ZM4.25 7.75v4.192l5.75 4.457 5.75-4.457V7.75H4.25Z" />
+            </svg>
+          </div>
+          <div>
+            <h1 className="font-display text-xl text-white">{selectedSpot.name}</h1>
+            <p className="text-xs text-white/30 font-mono">
+              {selectedSpot.lat.toFixed(4)}, {selectedSpot.lng.toFixed(4)}
+            </p>
+          </div>
+        </div>
+        <button
+          onClick={() => selectSpot(null)}
+          className="flex h-10 w-10 items-center justify-center rounded-full bg-white/5 text-white/40 hover:text-white hover:bg-white/10 transition"
+        >
+          <svg viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5">
+            <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
+          </svg>
+        </button>
+      </header>
+
+      {/* Content area */}
+      <div className="flex-1 overflow-y-auto px-5 py-6 sm:px-8">
+        {loading ? (
+          <div className="flex items-center justify-center h-40">
+            <div className="text-white/30 text-sm">Loading stories...</div>
+          </div>
+        ) : spotPins.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-40 gap-2">
+            <p className="text-white/30 text-sm">No stories here yet.</p>
+            <p className="text-white/20 text-xs">Be the first to drop one!</p>
+          </div>
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {spotPins.map((pin) => (
+              <PinCard key={pin.id} pin={pin} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Add story FAB */}
+      {!composeOpen && (
+        <button
+          onClick={() => setComposeOpen(true)}
+          className="absolute bottom-6 right-6 flex items-center gap-2 rounded-full bg-amber-400 px-5 py-3 text-sm font-semibold text-black shadow-xl hover:bg-amber-300 transition active:scale-95"
+          style={{ boxShadow: "0 0 32px rgba(251,191,36,0.35)" }}
+        >
+          <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
+            <path fillRule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm.75-11.25a.75.75 0 0 0-1.5 0v2.5h-2.5a.75.75 0 0 0 0 1.5h2.5v2.5a.75.75 0 0 0 1.5 0v-2.5h2.5a.75.75 0 0 0 0-1.5h-2.5v-2.5Z" clipRule="evenodd" />
+          </svg>
+          Add Story
+        </button>
+      )}
+
+      {/* Inline compose form */}
+      {composeOpen && (
+        <div className="border-t border-white/[0.06] px-5 py-5 sm:px-8 bg-[#13131a]">
+          <form onSubmit={handleSubmitPin} className="max-w-lg mx-auto flex flex-col gap-3">
+            <div className="flex items-center justify-between">
+              <h3 className="font-display text-base text-white">New Story</h3>
+              <button
+                type="button"
+                onClick={() => { setComposeOpen(false); setError(null); }}
+                className="text-white/30 hover:text-white text-sm transition"
+              >
+                Cancel
+              </button>
+            </div>
+
+            {/* Category pills */}
+            <div className="flex flex-wrap gap-1.5">
+              {CATEGORIES.map((cat) => (
+                <button
+                  key={cat.id}
+                  type="button"
+                  onClick={() => setCategory(cat.id)}
+                  className={`rounded-full border px-2.5 py-0.5 text-xs font-medium transition ${
+                    category === cat.id
+                      ? cat.color
+                      : "border-white/10 text-white/30 hover:border-white/20 hover:text-white/50"
+                  }`}
+                >
+                  {cat.label}
+                </button>
+              ))}
+            </div>
+
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value.slice(0, 60))}
+              placeholder="Title (max 60)"
+              maxLength={60}
+              required
+              className="w-full rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm text-white placeholder-white/20 outline-none focus:border-amber-400/40 focus:ring-1 focus:ring-amber-400/20 transition"
+            />
+            <textarea
+              value={body}
+              onChange={(e) => setBody(e.target.value.slice(0, 280))}
+              placeholder="Tell your story... (max 280)"
+              maxLength={280}
+              rows={3}
+              required
+              className="w-full resize-none rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm text-white placeholder-white/20 outline-none focus:border-amber-400/40 focus:ring-1 focus:ring-amber-400/20 transition"
+            />
+            {error && (
+              <p className="text-xs text-red-400 bg-red-400/10 rounded-lg px-3 py-2">{error}</p>
+            )}
+            <button
+              type="submit"
+              disabled={submitting || !title.trim() || !body.trim()}
+              className="rounded-xl bg-amber-400 py-2.5 text-sm font-semibold text-black hover:bg-amber-300 disabled:opacity-40 disabled:cursor-not-allowed transition"
+            >
+              {submitting ? "Dropping..." : "Drop Story"}
+            </button>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/store/spots.ts
+++ b/web/src/store/spots.ts
@@ -1,0 +1,60 @@
+import { create } from "zustand";
+import type { Pin } from "./pins";
+
+export type Spot = {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+  type: string;
+  createdAt: string;
+};
+
+type SpotsStore = {
+  // Admin
+  isAdmin: boolean;
+  setAdmin: (on: boolean) => void;
+
+  // Spots on the map
+  spots: Spot[];
+  setSpots: (spots: Spot[]) => void;
+  addSpot: (spot: Spot) => void;
+
+  // Spot drop mode (admin placing a spot)
+  spotDropMode: boolean;
+  setSpotDropMode: (on: boolean) => void;
+  pendingSpotCoords: { lat: number; lng: number } | null;
+  spotComposeOpen: boolean;
+  openSpotCompose: (coords: { lat: number; lng: number }) => void;
+  closeSpotCompose: () => void;
+
+  // Fullscreen spot view
+  selectedSpot: Spot | null;
+  spotPins: Pin[];
+  selectSpot: (spot: Spot | null) => void;
+  setSpotPins: (pins: Pin[]) => void;
+  addSpotPin: (pin: Pin) => void;
+};
+
+export const useSpotsStore = create<SpotsStore>((set) => ({
+  isAdmin: false,
+  setAdmin: (isAdmin) => set({ isAdmin }),
+
+  spots: [],
+  setSpots: (spots) => set({ spots }),
+  addSpot: (spot) => set((s) => ({ spots: [spot, ...s.spots] })),
+
+  spotDropMode: false,
+  setSpotDropMode: (spotDropMode) => set({ spotDropMode }),
+  pendingSpotCoords: null,
+  spotComposeOpen: false,
+  openSpotCompose: (coords) =>
+    set({ pendingSpotCoords: coords, spotComposeOpen: true, spotDropMode: false }),
+  closeSpotCompose: () => set({ spotComposeOpen: false, pendingSpotCoords: null }),
+
+  selectedSpot: null,
+  spotPins: [],
+  selectSpot: (spot) => set({ selectedSpot: spot, spotPins: [] }),
+  setSpotPins: (spotPins) => set({ spotPins }),
+  addSpotPin: (pin) => set((s) => ({ spotPins: [pin, ...s.spotPins] })),
+}));


### PR DESCRIPTION
- Added Spot model to Prisma schema with name, lat, lng, type fields
- Added optional spotId foreign key on Pin for pins inside a spot
- Created spots Zustand store with admin state, spot drop mode, and spot view state
- Added API routes: POST /api/admin/verify (code 1612), GET+POST /api/spots, GET /api/spots/[id], GET+POST /api/spots/[id]/pins
- Built AdminLock component: lock icon (bottom-left) prompts for admin code, unlocks "Place Spot" mode with admin controls
- Built SpotCompose modal for admins to name and place spots on the map
- Added custom building SVG marker for spots on the map (purple, distinct from pins)
- Built SpotView fullscreen overlay: shows spot name/coords, lists all nested pins as cards, and includes an inline compose form to add stories to the spot
- Wired spot drop mode banner, spot fetcher, and spot click handling into AppMap
- Updated map page to integrate all new components

https://claude.ai/code/session_017WZabcKjm8X2WV4a9boT3a