### PR TITLE
feat: admin can delete spots from SpotView

### DIFF
--- a/web/src/app/api/spots/[id]/route.ts
+++ b/web/src/app/api/spots/[id]/route.ts
@@ -3,6 +3,8 @@ import { db } from "@/lib/db";
 
 type Params = { params: Promise<{ id: string }> };
 
+const ADMIN_CODE = process.env.ADMIN_CODE ?? "1612";
+
 // ─── GET /api/spots/[id] — public ───────────────────────────────────────────
 
 export async function GET(_req: NextRequest, { params }: Params) {
@@ -18,4 +20,24 @@ export async function GET(_req: NextRequest, { params }: Params) {
   }
 
   return NextResponse.json(spot);
+}
+
+// ─── DELETE /api/spots/[id] — admin only ────────────────────────────────────
+
+export async function DELETE(req: NextRequest, { params }: Params) {
+  const { id } = await params;
+
+  const body = await req.json().catch(() => null);
+  if (!body || body.adminCode !== ADMIN_CODE) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  const spot = await db.spot.findUnique({ where: { id } });
+  if (!spot) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  await db.spot.delete({ where: { id } });
+
+  return NextResponse.json({ ok: true });
 }

--- a/web/src/components/AdminLock.tsx
+++ b/web/src/components/AdminLock.tsx
@@ -24,7 +24,7 @@ export function AdminLock() {
         setError(true);
         return;
       }
-      setAdmin(true);
+      setAdmin(true, code);
       setShowDialog(false);
       setCode("");
     } finally {

--- a/web/src/components/SpotView.tsx
+++ b/web/src/components/SpotView.tsx
@@ -66,10 +66,11 @@ function PinCard({ pin }: { pin: Pin }) {
 }
 
 export function SpotView() {
-  const { selectedSpot, spotPins, selectSpot, setSpotPins, addSpotPin } =
+  const { selectedSpot, spotPins, selectSpot, setSpotPins, addSpotPin, isAdmin, adminCode, removeSpot } =
     useSpotsStore();
 
   const [loading, setLoading] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const [composeOpen, setComposeOpen] = useState(false);
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
@@ -122,6 +123,25 @@ export function SpotView() {
     }
   }
 
+  async function handleDelete() {
+    if (!selectedSpot || !confirm(`Delete "${selectedSpot.name}"? This cannot be undone.`)) return;
+    setDeleting(true);
+    try {
+      const res = await fetch(`/api/spots/${selectedSpot.id}`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ adminCode }),
+      });
+      if (!res.ok) throw new Error();
+      removeSpot(selectedSpot.id);
+      selectSpot(null);
+    } catch {
+      alert("Failed to delete spot.");
+    } finally {
+      setDeleting(false);
+    }
+  }
+
   return (
     <div className="fixed inset-0 z-50 flex flex-col bg-[#0a0a0f]">
       {/* Header */}
@@ -140,14 +160,28 @@ export function SpotView() {
             </p>
           </div>
         </div>
-        <button
-          onClick={() => selectSpot(null)}
-          className="flex h-10 w-10 items-center justify-center rounded-full bg-white/5 text-white/40 hover:text-white hover:bg-white/10 transition"
-        >
-          <svg viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5">
-            <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
-          </svg>
-        </button>
+        <div className="flex items-center gap-2">
+          {isAdmin && (
+            <button
+              onClick={handleDelete}
+              disabled={deleting}
+              className="flex h-10 w-10 items-center justify-center rounded-full bg-red-500/10 text-red-400 hover:bg-red-500/20 hover:text-red-300 disabled:opacity-40 transition"
+              title="Delete spot"
+            >
+              <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
+                <path fillRule="evenodd" d="M8.75 1A2.75 2.75 0 0 0 6 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 1 0 .23 1.482l.149-.022.841 10.518A2.75 2.75 0 0 0 7.596 19h4.807a2.75 2.75 0 0 0 2.742-2.53l.841-10.52.149.023a.75.75 0 0 0 .23-1.482A41.03 41.03 0 0 0 14 4.193V3.75A2.75 2.75 0 0 0 11.25 1h-2.5ZM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4ZM8.58 7.72a.75.75 0 0 0-1.5.06l.3 7.5a.75.75 0 1 0 1.5-.06l-.3-7.5Zm4.34.06a.75.75 0 1 0-1.5-.06l-.3 7.5a.75.75 0 1 0 1.5.06l.3-7.5Z" clipRule="evenodd" />
+              </svg>
+            </button>
+          )}
+          <button
+            onClick={() => selectSpot(null)}
+            className="flex h-10 w-10 items-center justify-center rounded-full bg-white/5 text-white/40 hover:text-white hover:bg-white/10 transition"
+          >
+            <svg viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5">
+              <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
+            </svg>
+          </button>
+        </div>
       </header>
 
       {/* Content area */}

--- a/web/src/store/spots.ts
+++ b/web/src/store/spots.ts
@@ -13,12 +13,14 @@ export type Spot = {
 type SpotsStore = {
   // Admin
   isAdmin: boolean;
-  setAdmin: (on: boolean) => void;
+  adminCode: string;
+  setAdmin: (on: boolean, code?: string) => void;
 
   // Spots on the map
   spots: Spot[];
   setSpots: (spots: Spot[]) => void;
   addSpot: (spot: Spot) => void;
+  removeSpot: (id: string) => void;
 
   // Spot drop mode (admin placing a spot)
   spotDropMode: boolean;
@@ -38,11 +40,13 @@ type SpotsStore = {
 
 export const useSpotsStore = create<SpotsStore>((set) => ({
   isAdmin: false,
-  setAdmin: (isAdmin) => set({ isAdmin }),
+  adminCode: "",
+  setAdmin: (isAdmin, code) => set({ isAdmin, ...(code !== undefined ? { adminCode: code } : {}) }),
 
   spots: [],
   setSpots: (spots) => set({ spots }),
   addSpot: (spot) => set((s) => ({ spots: [spot, ...s.spots] })),
+  removeSpot: (id) => set((s) => ({ spots: s.spots.filter((sp) => sp.id !== id) })),
 
   spotDropMode: false,
   setSpotDropMode: (spotDropMode) => set({ spotDropMode }),


### PR DESCRIPTION
- DELETE /api/spots/[id] endpoint protected by admin code
- Store adminCode in spots store when admin unlocks
- Red trash button appears in SpotView header when logged in as admin
- Confirms before deleting, removes spot from map on success

https://claude.ai/code/session_017WZabcKjm8X2WV4a9boT3a