### PR TITLE
fix: apply Clerk dark baseTheme to sign-in and sign-up pages

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@clerk/nextjs": "^6.39.0",
+        "@clerk/themes": "^2.4.57",
         "@libsql/client": "^0.17.0",
         "@prisma/adapter-libsql": "^7.4.2",
         "@prisma/client": "^7.4.2",
@@ -189,6 +190,19 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@clerk/themes": {
+      "version": "2.4.57",
+      "resolved": "https://registry.npmjs.org/@clerk/themes/-/themes-2.4.57.tgz",
+      "integrity": "sha512-Nb3bO79rMTU/MPVTC/dde6LG27/IgOMKIYi5KSvAmO4ZUHlj0OWufu6CMvz5OYVZ0YdyMnTBU2aPGRUiRzO+2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^3.47.2",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
       }
     },
     "node_modules/@clerk/types": {

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^6.39.0",
+    "@clerk/themes": "^2.4.57",
     "@libsql/client": "^0.17.0",
     "@prisma/adapter-libsql": "^7.4.2",
     "@prisma/client": "^7.4.2",

--- a/web/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/web/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,6 +1,8 @@
 import { SignIn } from "@clerk/nextjs";
+import { dark as clerkDark } from "@clerk/themes";
 
-const dark = {
+const appearance = {
+  baseTheme: clerkDark,
   variables: {
     colorBackground: "#13131a",
     colorInputBackground: "#1a1a26",
@@ -11,12 +13,13 @@ const dark = {
     colorPrimary: "#fbbf24",
     colorDanger: "#f87171",
     colorSuccess: "#34d399",
-    colorNeutral: "#ffffff",
+    colorNeutral: "#8b8fa8",
     borderRadius: "12px",
     fontFamily: "DM Sans, system-ui, sans-serif",
     fontSize: "14px",
   },
   elements: {
+    rootBox: { width: "100%" },
     card: {
       background: "#13131a",
       border: "1px solid rgba(255,255,255,0.08)",
@@ -64,7 +67,7 @@ const dark = {
 export default function SignInPage() {
   return (
     <main className="flex min-h-screen items-center justify-center bg-[#0a0a0f]">
-      <SignIn appearance={dark} />
+      <SignIn appearance={appearance} />
     </main>
   );
 }

--- a/web/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/web/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,9 +1,73 @@
 import { SignUp } from "@clerk/nextjs";
+import { dark as clerkDark } from "@clerk/themes";
+
+const appearance = {
+  baseTheme: clerkDark,
+  variables: {
+    colorBackground: "#13131a",
+    colorInputBackground: "#1a1a26",
+    colorInputText: "#ffffff",
+    colorText: "#ffffff",
+    colorTextSecondary: "rgba(255,255,255,0.55)",
+    colorTextOnPrimaryBackground: "#000000",
+    colorPrimary: "#fbbf24",
+    colorDanger: "#f87171",
+    colorSuccess: "#34d399",
+    colorNeutral: "#8b8fa8",
+    borderRadius: "12px",
+    fontFamily: "DM Sans, system-ui, sans-serif",
+    fontSize: "14px",
+  },
+  elements: {
+    rootBox: { width: "100%" },
+    card: {
+      background: "#13131a",
+      border: "1px solid rgba(255,255,255,0.08)",
+      boxShadow: "0 32px 64px rgba(0,0,0,0.6)",
+    },
+    headerTitle: { color: "#ffffff", fontSize: "20px" },
+    headerSubtitle: { color: "rgba(255,255,255,0.45)" },
+    socialButtonsBlockButton: {
+      background: "rgba(255,255,255,0.05)",
+      border: "1px solid rgba(255,255,255,0.12)",
+      color: "#ffffff",
+    },
+    socialButtonsBlockButtonText: { color: "#ffffff", fontWeight: "500" },
+    socialButtonsBlockButtonArrow: { color: "rgba(255,255,255,0.4)" },
+    dividerLine: { background: "rgba(255,255,255,0.07)" },
+    dividerText: { color: "rgba(255,255,255,0.3)" },
+    formFieldLabel: { color: "rgba(255,255,255,0.6)", fontSize: "12px" },
+    formFieldInput: {
+      background: "#1a1a26",
+      border: "1px solid rgba(255,255,255,0.1)",
+      color: "#ffffff",
+    },
+    formFieldInputShowPasswordButton: { color: "rgba(255,255,255,0.4)" },
+    formButtonPrimary: {
+      background: "#fbbf24",
+      color: "#000000",
+      fontWeight: "600",
+    },
+    footerActionText: { color: "rgba(255,255,255,0.4)" },
+    footerActionLink: { color: "#fbbf24" },
+    identityPreviewText: { color: "#ffffff" },
+    identityPreviewEditButton: { color: "#fbbf24" },
+    formResendCodeLink: { color: "#fbbf24" },
+    otpCodeFieldInput: {
+      background: "#1a1a26",
+      border: "1px solid rgba(255,255,255,0.1)",
+      color: "#ffffff",
+    },
+    alertText: { color: "rgba(255,255,255,0.7)" },
+    formFieldError: { color: "#f87171" },
+    badge: { background: "rgba(251,191,36,0.15)", color: "#fbbf24" },
+  },
+} as const;
 
 export default function SignUpPage() {
   return (
-    <main className="flex min-h-screen items-center justify-center">
-      <SignUp />
+    <main className="flex min-h-screen items-center justify-center bg-[#0a0a0f]">
+      <SignUp appearance={appearance} />
     </main>
   );
 }


### PR DESCRIPTION
Without a baseTheme, Clerk defaults to its light theme and custom variable/element overrides only partially apply, leaving text black on the dark background. Fixes by:
- Installing @clerk/themes and using dark as baseTheme
- Fixing colorNeutral from #ffffff (which generates a white neutral scale causing invisible text) to a mid-gray #8b8fa8
- Adding full appearance config to sign-up page which had none

https://claude.ai/code/session_01KhxxPiPSxjex3MyTDsD8vo