### PR TITLE
Add light mode for map and hide spot stories from map view

### DIFF
--- a/web/src/app/api/pins/route.ts
+++ b/web/src/app/api/pins/route.ts
@@ -22,6 +22,7 @@ export async function GET(req: NextRequest) {
   const pins = await db.pin.findMany({
     where: {
       status: "visible",
+      spotId: null,
       lat: { gte: swLat, lte: neLat },
       lng: { gte: swLng, lte: neLng },
     },

--- a/web/src/app/api/spots/route.ts
+++ b/web/src/app/api/spots/route.ts
@@ -32,6 +32,7 @@ export async function GET(req: NextRequest) {
       lng: true,
       type: true,
       createdAt: true,
+      _count: { select: { pins: true } },
     },
     orderBy: { createdAt: "desc" },
     take: 200,

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -318,3 +318,37 @@ body {
 .leaflet-control-attribution {
   display: none;
 }
+
+/* ── Light map mode overrides ── */
+.map-light .leaflet-container {
+  background: #f0ede8;
+}
+
+.map-light .leaflet-popup-content-wrapper {
+  background: rgba(255, 255, 255, 0.97);
+  color: #1f2937;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.12), 0 0 0 1px rgba(0,0,0,0.04);
+}
+.map-light .leaflet-popup-content {
+  color: #1f2937;
+}
+.map-light .leaflet-popup-tip-container .leaflet-popup-tip {
+  background: rgba(255, 255, 255, 0.97);
+}
+.map-light .leaflet-popup-close-button {
+  color: rgba(0, 0, 0, 0.35) !important;
+}
+.map-light .leaflet-popup-close-button:hover {
+  color: rgba(0, 0, 0, 0.7) !important;
+}
+
+.map-light .leaflet-control-zoom a {
+  background-color: rgba(255, 255, 255, 0.92) !important;
+  color: rgba(0, 0, 0, 0.65) !important;
+  border-color: rgba(0, 0, 0, 0.12) !important;
+}
+.map-light .leaflet-control-zoom a:hover {
+  background-color: rgba(255, 255, 255, 1) !important;
+  color: #7c3aed !important;
+}

--- a/web/src/app/map/page.tsx
+++ b/web/src/app/map/page.tsx
@@ -9,7 +9,7 @@ import { PinDetail } from "@/components/PinDetail";
 import { AdminLock } from "@/components/AdminLock";
 import { SpotCompose } from "@/components/SpotCompose";
 import { SpotView } from "@/components/SpotView";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 
 const AppMap = dynamic(
   () => import("@/components/AppMap").then((m) => m.AppMap),
@@ -17,6 +17,7 @@ const AppMap = dynamic(
 );
 
 export default function MapPage() {
+  const [lightMode, setLightMode] = useState(false);
   const { dropMode, setDropMode, selectPin, composeOpen } = usePinsStore();
   const { spotDropMode, spotComposeOpen, selectSpot } = useSpotsStore();
 
@@ -33,7 +34,7 @@ export default function MapPage() {
   return (
     <div className="relative h-screen w-screen overflow-hidden bg-[#0a0a0f]">
       {/* Full-screen map */}
-      <AppMap onPinClick={handlePinClick} onSpotClick={handleSpotClick} />
+      <AppMap onPinClick={handlePinClick} onSpotClick={handleSpotClick} lightMode={lightMode} />
 
       {/* ── Floating header ── */}
       <header className="pointer-events-none absolute top-0 left-0 right-0 z-20 flex items-center justify-between px-4 py-3 sm:px-6">
@@ -56,6 +57,27 @@ export default function MapPage() {
           </svg>
           <span className="font-display text-base italic text-white/80">RoguePoints</span>
         </a>
+
+        {/* Light mode toggle */}
+        <div className="pointer-events-auto flex items-center gap-2">
+          <button
+            onClick={() => setLightMode((v) => !v)}
+            title={lightMode ? "Switch to dark map" : "Switch to light map"}
+            className="flex h-9 w-9 items-center justify-center rounded-full border border-white/[0.08] bg-black/50 backdrop-blur-md text-white/70 hover:text-white hover:bg-black/70 transition"
+          >
+            {lightMode ? (
+              /* Moon icon */
+              <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
+                <path fillRule="evenodd" d="M7.455 2.004a.75.75 0 0 1 .26.77 7 7 0 0 0 9.958 7.967.75.75 0 0 1 1.067.853A8.5 8.5 0 1 1 6.647 1.921a.75.75 0 0 1 .808.083Z" clipRule="evenodd"/>
+              </svg>
+            ) : (
+              /* Sun icon */
+              <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
+                <path d="M10 2a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 10 2ZM10 15a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 10 15ZM10 7a3 3 0 1 0 0 6 3 3 0 0 0 0-6ZM15.657 5.404a.75.75 0 1 0-1.06-1.06l-1.061 1.06a.75.75 0 0 0 1.06 1.06l1.06-1.06ZM6.464 14.596a.75.75 0 1 0-1.06-1.06l-1.06 1.06a.75.75 0 0 0 1.06 1.06l1.06-1.06ZM18 10a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 18 10ZM5 10a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 5 10ZM14.596 15.657a.75.75 0 0 0 1.06-1.06l-1.06-1.061a.75.75 0 1 0-1.06 1.06l1.06 1.06ZM5.404 6.464a.75.75 0 0 0 1.06-1.06L5.404 4.343a.75.75 0 1 0-1.06 1.06l1.06 1.061Z"/>
+              </svg>
+            )}
+          </button>
+        </div>
 
         {/* User avatar */}
         <div className="pointer-events-auto rounded-full border border-white/[0.08] bg-black/50 backdrop-blur-md p-0.5">

--- a/web/src/components/AppMap.tsx
+++ b/web/src/components/AppMap.tsx
@@ -67,10 +67,13 @@ const SPOT_SVGS: Record<string, string> = {
   </svg>`,
 };
 
-function makeSpotIcon(type: string): L.DivIcon {
+function makeSpotIcon(type: string, hasPins: boolean = false): L.DivIcon {
   const svg = SPOT_SVGS[type] ?? SPOT_SVGS.school;
+  const dot = hasPins
+    ? `<div style="position:absolute;top:-3px;right:-3px;width:11px;height:11px;background:#f87171;border-radius:50%;border:2px solid white;box-shadow:0 0 6px rgba(248,113,113,0.7)"></div>`
+    : "";
   return L.divIcon({
-    html: svg,
+    html: `<div style="position:relative;display:inline-block;width:40px;height:44px">${svg}${dot}</div>`,
     className: "",
     iconSize: [40, 44],
     iconAnchor: [20, 44],
@@ -214,18 +217,18 @@ function MarkerLayer({ onPinClick }: { onPinClick: (pin: Pin) => void }) {
   return null;
 }
 
-// Renders spot markers with a custom building SVG
+// Renders spot markers with a custom building SVG and a dot if the spot has stories
 function SpotMarkerLayer({ onSpotClick }: { onSpotClick: (spot: Spot) => void }) {
   const map = useMap();
   const { spots } = useSpotsStore();
-  const markersRef = useRef<Map<string, L.Marker>>(new Map());
+  const markersRef = useRef<Map<string, { marker: L.Marker; pinCount: number }>>(new Map());
   const onSpotClickRef = useRef(onSpotClick);
   onSpotClickRef.current = onSpotClick;
 
   useEffect(() => {
     const currentIds = new Set(spots.map((s) => s.id));
 
-    for (const [id, marker] of markersRef.current) {
+    for (const [id, { marker }] of markersRef.current) {
       if (!currentIds.has(id)) {
         marker.remove();
         markersRef.current.delete(id);
@@ -233,14 +236,27 @@ function SpotMarkerLayer({ onSpotClick }: { onSpotClick: (spot: Spot) => void })
     }
 
     for (const spot of spots) {
-      if (markersRef.current.has(spot.id)) continue;
-      const marker = L.marker([spot.lat, spot.lng], { icon: makeSpotIcon(spot.type) })
+      const pinCount = spot._count?.pins ?? 0;
+      const existing = markersRef.current.get(spot.id);
+
+      // Skip if marker already exists with the same pin count
+      if (existing && existing.pinCount === pinCount) continue;
+
+      // Remove outdated marker so we can replace it
+      if (existing) {
+        existing.marker.remove();
+        markersRef.current.delete(spot.id);
+      }
+
+      const marker = L.marker([spot.lat, spot.lng], {
+        icon: makeSpotIcon(spot.type, pinCount > 0),
+      })
         .addTo(map)
         .on("click", (e) => {
           L.DomEvent.stopPropagation(e);
           onSpotClickRef.current(spot);
         });
-      markersRef.current.set(spot.id, marker);
+      markersRef.current.set(spot.id, { marker, pinCount });
     }
   }, [spots, map]);
 
@@ -250,31 +266,41 @@ function SpotMarkerLayer({ onSpotClick }: { onSpotClick: (spot: Spot) => void })
 type Props = {
   onPinClick: (pin: Pin) => void;
   onSpotClick: (spot: Spot) => void;
+  lightMode?: boolean;
 };
 
-export function AppMap({ onPinClick, onSpotClick }: Props) {
+export function AppMap({ onPinClick, onSpotClick, lightMode = false }: Props) {
   const { latitude, longitude, zoom } = useViewportStore();
 
+  const tileUrl = lightMode
+    ? "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
+    : "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png";
+
+  const bgColor = lightMode ? "#f0ede8" : "#0a0a0f";
+
   return (
-    <MapContainer
-      center={[latitude, longitude]}
-      zoom={zoom}
-      zoomControl={false}
-      attributionControl={false}
-      className="h-full w-full"
-      style={{ background: "#0a0a0f" }}
-    >
-      <TileLayer
-        url="https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
-        subdomains="abcd"
-        maxZoom={20}
-      />
-      <PinFetcher />
-      <SpotFetcher />
-      <MapClickHandler />
-      <CursorEffect />
-      <MarkerLayer onPinClick={onPinClick} />
-      <SpotMarkerLayer onSpotClick={onSpotClick} />
-    </MapContainer>
+    <div className={lightMode ? "map-light h-full w-full" : "map-dark h-full w-full"}>
+      <MapContainer
+        center={[latitude, longitude]}
+        zoom={zoom}
+        zoomControl={false}
+        attributionControl={false}
+        className="h-full w-full"
+        style={{ background: bgColor }}
+      >
+        <TileLayer
+          key={tileUrl}
+          url={tileUrl}
+          subdomains="abcd"
+          maxZoom={20}
+        />
+        <PinFetcher />
+        <SpotFetcher />
+        <MapClickHandler />
+        <CursorEffect />
+        <MarkerLayer onPinClick={onPinClick} />
+        <SpotMarkerLayer onSpotClick={onSpotClick} />
+      </MapContainer>
+    </div>
   );
 }

--- a/web/src/store/spots.ts
+++ b/web/src/store/spots.ts
@@ -8,6 +8,7 @@ export type Spot = {
   lng: number;
   type: string;
   createdAt: string;
+  _count?: { pins: number };
 };
 
 type SpotsStore = {


### PR DESCRIPTION
- Light mode toggle (sun/moon button) on the map header switches between CartoDB dark and light tiles with matching background and Leaflet control styles
- Spot pins (stories linked to a Spot) are now filtered out of the main map pin layer so they don't appear as standalone markers
- Spot icons now show a small red dot badge when the spot has stories, replacing the individual story markers
- Spots API returns _count.pins so the frontend knows whether to show the dot
- Light mode CSS scoped to .map-light wrapper so it never affects the lander

https://claude.ai/code/session_01WSvK1SY4VKhDHVjAAPGtpb