### PR TITLE
Default map screen to light mode

### DIFF
--- a/web/src/app/map/page.tsx
+++ b/web/src/app/map/page.tsx
@@ -17,7 +17,7 @@ const AppMap = dynamic(
 );
 
 export default function MapPage() {
-  const [lightMode, setLightMode] = useState(false);
+  const [lightMode, setLightMode] = useState(true);
   const { dropMode, setDropMode, selectPin, composeOpen } = usePinsStore();
   const { spotDropMode, spotComposeOpen, selectSpot } = useSpotsStore();
 


### PR DESCRIPTION
Changes useState(false) to useState(true) for lightMode in MapPage so the map loads in light mode by default instead of dark mode.

https://claude.ai/code/session_016QWFMQ5yVJ4xZYWLGMidQB